### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -15,7 +15,7 @@ TiltSwitch	KEYWORD1
 CapacitiveSwitch	KEYWORD1
 PiezoKnockSensor	KEYWORD1
 Player	KEYWORD1
-Knob KEYWORD1
+Knob	KEYWORD1
 Joystick	KEYWORD1
 Wheels	KEYWORD1
 IRArray	KEYWORD1


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords