### PR TITLE
Use Unix EOL in all files

### DIFF
--- a/src/CapacitiveSwitch.cpp
+++ b/src/CapacitiveSwitch.cpp
@@ -1,1 +1,22 @@
-#include "EducationShield.h"#include <CapacitiveSensor.h>CapacitiveSwitch::CapacitiveSwitch(int pin_in,int pin):Button(pin,HIGH),sensor(pin_in,pin){}void CapacitiveSwitch::config(int threshold){	this->threshold=threshold;}void CapacitiveSwitch::test(){	Serial.println(getValue());}long CapacitiveSwitch::getValue(int min){	int val=sensor.capacitiveSensor(30);	if(val<min)		val=0;	return val;}bool CapacitiveSwitch::getState(){	return getValue()>threshold;}
+#include "EducationShield.h"
+#include <CapacitiveSensor.h>
+
+CapacitiveSwitch::CapacitiveSwitch(int pin_in,int pin):Button(pin,HIGH),sensor(pin_in,pin){
+
+}
+
+void CapacitiveSwitch::config(int threshold){
+	this->threshold=threshold;
+}
+void CapacitiveSwitch::test(){
+	Serial.println(getValue());
+}
+long CapacitiveSwitch::getValue(int min){
+	int val=sensor.capacitiveSensor(30);
+	if(val<min)
+		val=0;
+	return val;
+}
+bool CapacitiveSwitch::getState(){
+	return getValue()>threshold;
+}


### PR DESCRIPTION
Every file in the repository except CapacitiveSwitch.cpp uses Unix EOL. CapacitiveSwitch.cpp used Mac EOL, which made it extremely difficult to view the file on GitHub.

![clipboard01](https://user-images.githubusercontent.com/8572152/43472750-2098a8e0-94a3-11e8-8871-e590f1946b0e.png)