### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Is intended to be used with the Education Shield provided in the CTC k
 category=Other
 url=https://create.arduino.cc/ctc/101/
 architectures=avr,arc32
+depends=Servo

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EducationShield
-version=1.4.8
+version=1.4.9
 author=Arduino LLC
 maintainer=Arduino
 sentence=Library used for the completion of all the projects related to CTC


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes Library Manager to offer to install the dependencies during installation of this library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format