### PR TITLE
Correct typo in comment

### DIFF
--- a/examples/Block3-Magic/Projects/BinaryLP/Processing/binary_LP_disc/binary_LP_disc.pde
+++ b/examples/Block3-Magic/Projects/BinaryLP/Processing/binary_LP_disc/binary_LP_disc.pde
@@ -263,7 +263,7 @@ void calculateHypotenuse(){
 //*********************************************************************************
 void redrawButton(){
   
-  //  Calcuates if mouse is hovering over button and changes the fill accordingly
+  //  Calculates if mouse is hovering over button and changes the fill accordingly
   if(newY<topLimit && newY>bottomLimit && newX>= leftLimit && newX<=rightLimit){
       fill(0);
     }


### PR DESCRIPTION
A misspelling of the word "calculates" caused a failure of the spell check run by the repository's continuous integration system:

https://github.com/arduino-libraries/EducationShield/runs/7968534525?check_suite_focus=true#step:4:17

```text
Error: ./examples/Block3-Magic/Projects/BinaryLP/Processing/binary_LP_disc/binary_LP_disc.pde:266: Calcuates ==> Calculates
```